### PR TITLE
Behebt das Erzeugen eines absoluten Pfades

### DIFF
--- a/HT3/sw/lib/ht_utils.py
+++ b/HT3/sw/lib/ht_utils.py
@@ -177,7 +177,7 @@ class cht_utils(object):
         else:
             current_path = os.path.abspath('.')
             find_index = current_path.find(find_separator)
-            sliced_path = current_path[0:find_index]
+            sliced_path = current_path
             if find_index > 0 and len(current_path) > 2:
                 sliced_path = current_path[0:find_index + len(find_separator)]
             my_abspath = os.path.abspath(os.path.join(sliced_path, path))


### PR DESCRIPTION
Bei mir liegt das Projekt nicht in einem Unterpfad unter ./sw sondern direkt in /opt/HT3, weshalb er sich immer beschwerte, dass bestimmte Logfiles nicht unter /opt/HT/var/log/xxx erstellt werden konnten. Da find '-1' zurückgibt wenn der String nicht gefunden werden konnte hat er mir immer das letzte Zeichen weggeschnitten und das als Pfad verwendet.